### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -23,7 +23,7 @@ class action_plugin_dokumicrobugtracker extends DokuWiki_Action_Plugin {
     /*
      * plugin should use this method to register its handlers with the dokuwiki's event controller
      */
-    function register(&$controller) {
+    function register(Doku_Event_Handler $controller) {
         $controller->register_hook('TPL_METAHEADER_OUTPUT', 'BEFORE', $this, 'init_css');
     }
 

--- a/syntax.php
+++ b/syntax.php
@@ -37,7 +37,7 @@ class syntax_plugin_dokumicrobugtracker extends DokuWiki_Syntax_Plugin
     /**
     * Handle the match
     */
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
         $match = substr($match,22,-2); //strip markup from start and end
         //handle params
         $data = array();
@@ -84,7 +84,7 @@ class syntax_plugin_dokumicrobugtracker extends DokuWiki_Syntax_Plugin
     /**
     * Create output
     */
-    function render($mode, &$renderer, $data) {        
+    function render($mode, Doku_Renderer $renderer, $data) {        
         global $ID;
 		if ($mode == 'xhtml'){
 


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
